### PR TITLE
fix(db): use utf8mb4 charset for MySQL connections

### DIFF
--- a/v2/pkg/db/db.go
+++ b/v2/pkg/db/db.go
@@ -123,7 +123,7 @@ func NewDB(conf *dbconfig.Config, logger *log.LogCustom, dbCfg string, dbCfgRepl
 		name = conf.DBMysqlConfig[dbCfg].Name
 		tz = conf.DBMysqlConfig[dbCfg].Tz
 
-		dsn = fmt.Sprintf("%s:%s@tcp(%s:%s)/%s?charset=utf8&parseTime=True&loc=%s", user, password, host, port, name, tz)
+		dsn = fmt.Sprintf("%s:%s@tcp(%s:%s)/%s?charset=utf8mb4&parseTime=True&loc=%s", user, password, host, port, name, tz)
 
 		// open connection
 		DB, err = gorm.Open(mysql.Open(dsn))
@@ -136,7 +136,7 @@ func NewDB(conf *dbconfig.Config, logger *log.LogCustom, dbCfg string, dbCfgRepl
 
 		// create dsn replica if exist
 		if db, ok := conf.DBMysqlConfig[dbCfgReplica]; ok {
-			dsnReplica = fmt.Sprintf("%s:%s@tcp(%s:%s)/%s?charset=utf8&parseTime=True&loc=%s", db.User, db.Pass, db.Host, db.Port, db.Name, db.Tz)
+			dsnReplica = fmt.Sprintf("%s:%s@tcp(%s:%s)/%s?charset=utf8mb4&parseTime=True&loc=%s", db.User, db.Pass, db.Host, db.Port, db.Name, db.Tz)
 		}
 
 		// create dbresolver if using replica


### PR DESCRIPTION
## Summary
- Changes MySQL DSN charset from `utf8` (utf8mb3, 3-byte max) to `utf8mb4` (4-byte, full Unicode)
- Applies to both primary and replica connection strings

## Context
`charset=utf8` only supports characters up to 3 bytes, which excludes emoji and some CJK characters. This causes MySQL Error 3988 when persisting content with emoji to JSON columns (which internally use `utf8mb4_bin`).

## Changes
- `v2/pkg/db/db.go` line 126: `charset=utf8` → `charset=utf8mb4`
- `v2/pkg/db/db.go` line 139: `charset=utf8` → `charset=utf8mb4` (replica)